### PR TITLE
Step 2.1: Rich types ensure correctness

### DIFF
--- a/1_concepts/1_1_default_clone_copy/README.md
+++ b/1_concepts/1_1_default_clone_copy/README.md
@@ -81,7 +81,7 @@ After completing everything above, you should be able to answer (and understand 
 - What does [`Clone`] mean semantically?
 - What does [`Copy`] mean semantically? How is it connected with [`Clone`]? Which limitations does it have and why?
 
-
+### У всех detive есть проблема что ни вешают лишние
 
 
 [`Clone`]: https://doc.rust-lang.org/std/clone/trait.Clone.html

--- a/1_concepts/src/doubly_linked_list.rs
+++ b/1_concepts/src/doubly_linked_list.rs
@@ -103,7 +103,7 @@ impl<T> DoublyLinkedList<T> {
 
         node
     }
-    
+
     pub fn length(&self) -> usize {
         self.length
     }
@@ -163,35 +163,35 @@ where T: Copy
         Some(value)
     }
 
-    fn remove(&mut self, index: usize) -> Option<T> {
-        if index >= self.length {
-            return None;
-        }
-
-        if index == self.length - 1 {
-            return self.pop();
-        } else if index == 0 {
-            let head = self.head.take().unwrap();
-            let value = head.borrow_mut().value;
-            let next = head.borrow().next.clone().unwrap();
-
-            DoublyLinkedList::pop_node_left(next.clone());
-
-            self.head = Some(next);
-            self.length -= 1;
-
-            return Some(value);
-        }
-
-        let node = self.get_node(index).unwrap();
-        let value = node.borrow().value;
-        let prev = node.borrow().prev.clone().unwrap().upgrade().unwrap();
-
-        DoublyLinkedList::pop_node_right(prev.clone());
-
-        self.length -= 1;
-        Some(value)
-    }
+    // fn remove(&mut self, index: usize) -> Option<T> {
+    //     if index >= self.length {
+    //         return None;
+    //     }
+    //
+    //     if index == self.length - 1 {
+    //         return self.pop();
+    //     } else if index == 0 {
+    //         let head = self.head.take().unwrap();
+    //         let value = head.borrow_mut().value;
+    //         let next = head.borrow().next.clone().unwrap();
+    //
+    //         DoublyLinkedList::pop_node_left(next.clone());
+    //
+    //         self.head = Some(next);
+    //         self.length -= 1;
+    //
+    //         return Some(value);
+    //     }
+    //
+    //     let node = self.get_node(index).unwrap();
+    //     let value = node.borrow().value;
+    //     let prev = node.borrow().prev.clone().unwrap().upgrade().unwrap();
+    //
+    //     DoublyLinkedList::pop_node_right(prev.clone());
+    //
+    //     self.length -= 1;
+    //     Some(value)
+    // }
 
     fn update(&mut self, index: usize, value: T) -> Option<T> {
         if index >= self.length {
@@ -318,35 +318,35 @@ mod tests {
         assert!(list.tail.is_none());
     }
 
-    #[test]
-    fn test_doubly_linked_list_remove() {
-        let mut list = DoublyLinkedList::<u32>::new();
-
-        list.push(1);
-        list.push(2);
-        list.push(3);
-
-        assert_eq!(list.remove(1), Some(2));
-        assert_eq!(list.remove(1), Some(3));
-        assert_eq!(list.remove(1), None);
-        assert_eq!(list.remove(0), Some(1));
-
-        assert_eq!(list.length, 0);
-    }
-
-    #[test]
-    fn test_doubly_linked_list_remove_head() {
-        let mut list = DoublyLinkedList::<u32>::new();
-
-        list.push(1);
-        list.push(2);
-        list.push(3);
-
-        assert_eq!(list.remove(0), Some(1));
-        assert_eq!(list.remove(0), Some(2));
-        assert_eq!(list.remove(0), Some(3));
-
-        assert_eq!(list.remove(0), None);
-    }
+    // #[test]
+    // fn test_doubly_linked_list_remove() {
+    //     let mut list = DoublyLinkedList::<u32>::new();
+    //
+    //     list.push(1);
+    //     list.push(2);
+    //     list.push(3);
+    //
+    //     assert_eq!(list.remove(1), Some(2));
+    //     assert_eq!(list.remove(1), Some(3));
+    //     assert_eq!(list.remove(1), None);
+    //     assert_eq!(list.remove(0), Some(1));
+    //
+    //     assert_eq!(list.length, 0);
+    // }
+    //
+    // #[test]
+    // fn test_doubly_linked_list_remove_head() {
+    //     let mut list = DoublyLinkedList::<u32>::new();
+    //
+    //     list.push(1);
+    //     list.push(2);
+    //     list.push(3);
+    //
+    //     assert_eq!(list.remove(0), Some(1));
+    //     assert_eq!(list.remove(0), Some(2));
+    //     assert_eq!(list.remove(0), Some(3));
+    //
+    //     assert_eq!(list.remove(0), None);
+    // }
 
 }

--- a/1_concepts/src/doubly_linked_list.rs
+++ b/1_concepts/src/doubly_linked_list.rs
@@ -90,8 +90,6 @@ impl<T> DoublyLinkedList<T> {
         }
     }
 
-
-
     fn get_node(&self, index: usize) -> Option<Node<T>> {
         if index >= self.length {
             return None;
@@ -104,6 +102,10 @@ impl<T> DoublyLinkedList<T> {
         }
 
         node
+    }
+    
+    pub fn length(&self) -> usize {
+        self.length
     }
 }
 

--- a/1_concepts/src/doubly_linked_list.rs
+++ b/1_concepts/src/doubly_linked_list.rs
@@ -1,0 +1,350 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+use crate::list::List;
+use crate::list_node::ListNode;
+
+type Node<T> = Rc<RefCell<ListNode<T>>>;
+
+fn new_node<T>(value: T) -> Node<T> {
+    Rc::new(RefCell::new(ListNode::new(value)))
+}
+
+pub struct DoublyLinkedList<T> {
+    head: Option<Node<T>>,
+    tail: Option<Node<T>>,
+    length: usize,
+}
+
+impl<T> DoublyLinkedList<T> {
+    pub fn new() -> Self {
+        DoublyLinkedList {
+            head: None,
+            tail: None,
+            length: 0,
+        }
+    }
+
+    fn new_head(&mut self, value: T) {
+        let node = new_node(value);
+
+        self.head = Some(node.clone());
+        self.tail = Some(node);
+
+        self.length = 1;
+    }
+
+    /// Function that appends node_right to node_left
+    fn append_to_node_right(node_left: Node<T>, node_right: Node<T>) {
+        if node_left.borrow().next.is_none() {
+            // if no next node is tail, no need to get next one
+            node_right.borrow_mut().next = None;
+            node_right.borrow_mut().prev = Some(Rc::downgrade(&node_left));
+
+            node_left.borrow_mut().next = Some(node_right);
+        } else {
+            // we are not appending to the tail, so need to link with
+            // next to left node
+            let next = node_left.borrow_mut().next.take().unwrap();
+            node_left.borrow_mut().next = Some(node_right.clone());
+
+            next.borrow_mut().prev = Some(Rc::downgrade(&node_right));
+
+            node_right.borrow_mut().next = Some(next);
+            node_right.borrow_mut().prev = Some(Rc::downgrade(&node_left));
+        }
+    }
+
+    fn pop_node_right(node_left: Node<T>) {
+        let node_right = node_left.borrow_mut().next.take().unwrap();
+
+        if node_right.borrow().next.is_none() {
+            // right node is tail, just set node_left next to None
+            node_left.borrow_mut().next = None;
+
+            node_right.borrow_mut().prev.take();
+        } else {
+            // right node is not tail, so need to link left node
+            // with right node's next
+            let next = node_right.borrow_mut().next.take().unwrap();
+            node_left.borrow_mut().next = Some(next.clone());
+
+            next.borrow_mut().prev = Some(Rc::downgrade(&node_left));
+        }
+    }
+
+    fn pop_node_left(node_right: Node<T>) {
+        let node_left = node_right.borrow_mut().prev.take().unwrap().upgrade().unwrap();
+
+        if node_left.borrow().prev.is_none() {
+            // left node is head, just set node_right prev to None
+            node_right.borrow_mut().prev = None;
+
+            node_left.borrow_mut().next.take();
+        } else {
+            // left node is not head, so need to link right node
+            // with left node's prev
+            let prev = node_left.borrow_mut().prev.take().unwrap().upgrade().unwrap();
+            node_right.borrow_mut().prev = Some(Rc::downgrade(&prev));
+
+            prev.borrow_mut().next = Some(node_right);
+        }
+    }
+
+
+
+    fn get_node(&self, index: usize) -> Option<Node<T>> {
+        if index >= self.length {
+            return None;
+        }
+
+        let mut node = self.head.clone();
+
+        for _ in 0..index {
+            node = node.unwrap().borrow().next.clone();
+        }
+
+        node
+    }
+}
+
+impl<T> List<T> for DoublyLinkedList<T>
+where T: Copy
+{
+    fn push(&mut self, value: T) -> Option<usize> {
+        // if no head, create head
+        if self.head.is_none() {
+            self.new_head(value);
+            Some(0)
+        } else {
+            // if head is present
+            let node = new_node(value);
+            let tail = self.tail.take().unwrap();
+            DoublyLinkedList::append_to_node_right(tail, node.clone());
+
+            self.tail = Some(node);
+            self.length += 1;
+
+            Some(self.length - 1)
+        }
+    }
+
+    fn pop(&mut self) -> Option<T> {
+        return if self.length == 0 {
+            None
+        } else if self.length == 1 {
+            self.tail.take();
+            let node = self.head.take();
+            self.length = 0;
+
+            node.map(|n| n.borrow_mut().value)
+        } else {
+            let tail = self.tail.take().unwrap();
+            let value = tail.borrow_mut().value;
+            let prev = tail.borrow().prev.clone().unwrap().upgrade().unwrap();
+
+            DoublyLinkedList::pop_node_right(prev.clone());
+
+            self.tail = Some(prev);
+            self.length -= 1;
+
+            Some(value)
+        }
+    }
+
+    fn get(&self, index: usize) -> Option<T> {
+        if index >= self.length {
+            return None;
+        }
+
+        let node = self.get_node(index).unwrap();
+        let value = node.borrow().value;
+        Some(value)
+    }
+
+    fn remove(&mut self, index: usize) -> Option<T> {
+        if index >= self.length {
+            return None;
+        }
+
+        if index == self.length - 1 {
+            return self.pop();
+        } else if index == 0 {
+            let head = self.head.take().unwrap();
+            let value = head.borrow_mut().value;
+            let next = head.borrow().next.clone().unwrap();
+
+            DoublyLinkedList::pop_node_left(next.clone());
+
+            self.head = Some(next);
+            self.length -= 1;
+
+            return Some(value);
+        }
+
+        let node = self.get_node(index).unwrap();
+        let value = node.borrow().value;
+        let prev = node.borrow().prev.clone().unwrap().upgrade().unwrap();
+
+        DoublyLinkedList::pop_node_right(prev.clone());
+
+        self.length -= 1;
+        Some(value)
+    }
+
+    fn update(&mut self, index: usize, value: T) -> Option<T> {
+        if index >= self.length {
+            return None;
+        }
+
+        let node = self.get_node(index).unwrap();
+        let old_value = node.borrow_mut().value;
+        node.borrow_mut().value = value;
+
+        Some(old_value)
+    }
+
+    fn clear(&mut self) {
+        self.head.take();
+        self.tail.take();
+        self.length = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::doubly_linked_list::DoublyLinkedList;
+    use crate::list::List;
+
+    #[test]
+    fn test_doubly_linked_list_new() {
+        let list = DoublyLinkedList::<u32>::new();
+        assert_eq!(list.length, 0);
+        assert!(list.head.is_none());
+        assert!(list.tail.is_none());
+    }
+
+    #[test]
+    fn test_doubly_linked_list_new_head() {
+        let mut list = DoublyLinkedList::<u32>::new();
+
+        list.new_head(1);
+
+        assert_eq!(list.length, 1);
+        assert!(list.head.is_some());
+        assert!(list.tail.is_some());
+    }
+
+    #[test]
+    fn test_doubly_linked_list_push() {
+        let mut list = DoublyLinkedList::<u32>::new();
+
+        list.push(1);
+        list.push(2);
+        list.push(3);
+
+        assert_eq!(list.length, 3);
+        assert!(list.head.is_some());
+        assert!(list.tail.is_some());
+    }
+
+    #[test]
+    fn test_doubly_linked_list_pop_head() {
+        let mut list = DoublyLinkedList::<u32>::new();
+
+        assert_eq!(list.pop(), None);
+
+        list.push(1);
+
+        assert_eq!(list.pop(), Some(1));
+    }
+
+    #[test]
+    fn test_doubly_linked_list_pop_tail() {
+        let mut list = DoublyLinkedList::<u32>::new();
+
+        list.push(1);
+        list.push(2);
+        list.push(3);
+
+        assert_eq!(list.pop(), Some(3));
+        assert_eq!(list.pop(), Some(2));
+        assert_eq!(list.pop(), Some(1));
+        assert_eq!(list.pop(), None);
+    }
+
+    #[test]
+    fn test_doubly_linked_list_get() {
+        let mut list = DoublyLinkedList::<u32>::new();
+
+        list.push(1);
+        list.push(2);
+        list.push(3);
+
+        assert_eq!(list.get(0), Some(1));
+        assert_eq!(list.get(1), Some(2));
+        assert_eq!(list.get(2), Some(3));
+        assert_eq!(list.get(3), None);
+    }
+
+    #[test]
+    fn test_doubly_linked_list_update_head() {
+        let mut list = DoublyLinkedList::<u32>::new();
+
+        list.push(1);
+
+        assert_eq!(list.update(0, 2), Some(1));
+        assert_eq!(list.update(0, 3), Some(2));
+
+        assert_eq!(list.pop(), Some(3));
+        assert_eq!(list.update(0, 2), None);
+
+        assert_eq!(list.length, 0);
+    }
+
+    #[test]
+    fn test_doubly_linked_list_clear() {
+        let mut list = DoublyLinkedList::<u32>::new();
+
+        list.push(1);
+        list.push(2);
+        list.push(3);
+
+        list.clear();
+
+        assert_eq!(list.length, 0);
+        assert!(list.head.is_none());
+        assert!(list.tail.is_none());
+    }
+
+    #[test]
+    fn test_doubly_linked_list_remove() {
+        let mut list = DoublyLinkedList::<u32>::new();
+
+        list.push(1);
+        list.push(2);
+        list.push(3);
+
+        assert_eq!(list.remove(1), Some(2));
+        assert_eq!(list.remove(1), Some(3));
+        assert_eq!(list.remove(1), None);
+        assert_eq!(list.remove(0), Some(1));
+
+        assert_eq!(list.length, 0);
+    }
+
+    #[test]
+    fn test_doubly_linked_list_remove_head() {
+        let mut list = DoublyLinkedList::<u32>::new();
+
+        list.push(1);
+        list.push(2);
+        list.push(3);
+
+        assert_eq!(list.remove(0), Some(1));
+        assert_eq!(list.remove(0), Some(2));
+        assert_eq!(list.remove(0), Some(3));
+
+        assert_eq!(list.remove(0), None);
+    }
+
+}

--- a/1_concepts/src/list.rs
+++ b/1_concepts/src/list.rs
@@ -1,0 +1,45 @@
+/// Common trait for list with some basic operations
+pub trait List<T> {
+    /// Push a value to the list's tail
+    /// # Arguments
+    /// * `value` - The value to push
+    /// # Returns
+    /// * `Option<usize>` - The index of the value in the list
+    fn push(&mut self, value: T) -> Option<usize>;
+
+    /// Pop a value from the list's tail
+    /// # Returns
+    /// * `Option<T>` - The value from the list's tail
+    fn pop(&mut self) -> Option<T>;
+
+    /// Get a value from the list by index
+    /// # Arguments
+    /// * `index` - The index of the value to get
+    /// # Returns
+    /// * `Option<T>` - The value from the list
+    fn get(&self, index: usize) -> Option<T>;
+    
+    /// Remove a value from the list by index
+    /// # Arguments
+    /// * `index` - The index of the value to remove
+    /// # Returns
+    /// * `Option<T>` - The value from the list
+    fn remove(&mut self, index: usize) -> Option<T>;
+
+    /// Update a value in the list by index
+    /// # Arguments
+    /// * `index` - The index of the value to update
+    /// * `value` - The new value
+    /// # Returns
+    /// * `Option<T>` - The old value
+    fn update(&mut self, index: usize, value: T) -> Option<T>;
+
+    /// Clear the list. This should remove all values from the list
+    /// # Returns
+    /// * `()` - Nothing
+    fn clear(&mut self);
+}
+
+pub trait AdvancedList<T> {
+        
+}

--- a/1_concepts/src/list.rs
+++ b/1_concepts/src/list.rs
@@ -19,12 +19,12 @@ pub trait List<T> {
     /// * `Option<T>` - The value from the list
     fn get(&self, index: usize) -> Option<T>;
     
-    /// Remove a value from the list by index
-    /// # Arguments
-    /// * `index` - The index of the value to remove
-    /// # Returns
-    /// * `Option<T>` - The value from the list
-    fn remove(&mut self, index: usize) -> Option<T>;
+    // /// Remove a value from the list by index
+    // /// # Arguments
+    // /// * `index` - The index of the value to remove
+    // /// # Returns
+    // /// * `Option<T>` - The value from the list
+    // fn remove(&mut self, index: usize) -> Option<T>;
 
     /// Update a value in the list by index
     /// # Arguments

--- a/1_concepts/src/list_node.rs
+++ b/1_concepts/src/list_node.rs
@@ -1,0 +1,33 @@
+use std::cell::RefCell;
+use std::rc::{Rc, Weak};
+
+#[derive(Debug)]
+pub struct ListNode<T> {
+    pub value: T,
+    pub next: Option<Rc<RefCell<ListNode<T>>>>,
+    pub prev: Option<Weak<RefCell<ListNode<T>>>>,
+}
+
+
+impl<T> ListNode<T> {
+    pub fn new(value: T) -> Self {
+        ListNode {
+            value,
+            next: None,
+            prev: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_list_node() {
+        let node = ListNode::new(1);
+        assert_eq!(node.value, 1);
+        assert!(node.next.is_none());
+        assert!(node.prev.is_none());
+    }
+}

--- a/1_concepts/src/main.rs
+++ b/1_concepts/src/main.rs
@@ -6,6 +6,7 @@ mod list_node;
 mod list;
 mod parallel_list;
 mod parallel_node;
+mod real_parallel_list;
 
 fn main() {
     let mut list = DoublyLinkedList::<u32>::new();

--- a/1_concepts/src/main.rs
+++ b/1_concepts/src/main.rs
@@ -4,6 +4,8 @@ use crate::list::List;
 mod doubly_linked_list;
 mod list_node;
 mod list;
+mod parallel_list;
+mod parallel_node;
 
 fn main() {
     let mut list = DoublyLinkedList::<u32>::new();

--- a/1_concepts/src/main.rs
+++ b/1_concepts/src/main.rs
@@ -1,3 +1,16 @@
+use crate::doubly_linked_list::DoublyLinkedList;
+use crate::list::List;
+
+mod doubly_linked_list;
+mod list_node;
+mod list;
+
 fn main() {
-    println!("Implement me!");
+    let mut list = DoublyLinkedList::<u32>::new();
+
+    for i in 1..=1000 {
+        list.push(i);
+    }
+
+    list.clear();
 }

--- a/1_concepts/src/parallel_list.rs
+++ b/1_concepts/src/parallel_list.rs
@@ -1,0 +1,116 @@
+use std::sync::{Arc, Mutex};
+use crate::doubly_linked_list::DoublyLinkedList;
+use crate::list::List;
+
+
+pub struct ParallelDoublyLinkedList<T> {
+    list: Arc<Mutex<DoublyLinkedList<T>>>
+}
+
+impl<T> ParallelDoublyLinkedList<T> {
+    pub fn new() -> Self {
+        ParallelDoublyLinkedList {
+            list: Arc::new(Mutex::new(DoublyLinkedList::<T>::new()))
+        }
+    }
+}
+
+
+impl<T> Clone for ParallelDoublyLinkedList<T> {
+    fn clone(&self) -> Self {
+         ParallelDoublyLinkedList {
+             list: self.list.clone()
+         }
+    }
+}
+
+unsafe impl<T> Send for ParallelDoublyLinkedList<T> {}
+unsafe impl<T> Sync for ParallelDoublyLinkedList<T> {}
+
+impl<T> List<T> for ParallelDoublyLinkedList<T>
+where T: Copy
+{
+    fn push(&mut self, value: T) -> Option<usize> {
+        let mut list = self.list.lock().unwrap();
+        list.push(value)
+    }
+
+    fn pop(&mut self) -> Option<T> {
+        let mut list = self.list.lock().unwrap();
+        list.pop()
+    }
+
+    fn get(&self, index: usize) -> Option<T> {
+        let list = self.list.lock().unwrap();
+        list.get(index)
+    }
+
+    fn remove(&mut self, index: usize) -> Option<T> {
+        let mut list = self.list.lock().unwrap();
+        list.remove(index)
+    }
+
+    fn update(&mut self, index: usize, value: T) -> Option<T> {
+        let mut list = self.list.lock().unwrap();
+        list.update(index, value)
+    }
+
+    fn clear(&mut self) {
+        let mut list = self.list.lock().unwrap();
+        list.clear()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parallel_doubly_linked_list() {
+        let list = ParallelDoublyLinkedList::<u32>::new();
+
+        assert_eq!(list.list.lock().unwrap().length(), 0);
+    }
+
+    #[test]
+    fn test_parallel_doubly_linked_list_push() {
+        let mut list = ParallelDoublyLinkedList::<u32>::new();
+
+        list.push(1);
+        list.push(2);
+        list.push(3);
+
+        assert_eq!(list.list.lock().unwrap().length(), 3);
+        assert_eq!(list.list.lock().unwrap().get(0).unwrap(), 1);
+    }
+
+    #[test]
+    fn test_parallel_doubly_linked_list_push_parallel() {
+        let mut list = ParallelDoublyLinkedList::<u32>::new();
+
+        let mut list_clone = list.clone();
+
+        let handle = std::thread::spawn(move || {
+            list_clone.push(1);
+            list_clone.push(2);
+            list_clone.push(3);
+        });
+
+        let pos4= list.push(4);
+        let pos5 = list.push(5);
+        let pos6 = list.push(6);
+
+        handle.join().unwrap();
+
+        assert_eq!(list.list.lock().unwrap().length(), 6);
+
+        assert!(pos4.is_some());
+        assert!(pos5.is_some());
+        assert!(pos6.is_some());
+
+        assert_eq!(list.list.lock().unwrap().get(pos4.unwrap()).unwrap(), 4);
+        assert_eq!(list.list.lock().unwrap().get(pos5.unwrap()).unwrap(), 5);
+        assert_eq!(list.list.lock().unwrap().get(pos6.unwrap()).unwrap(), 6);
+    }
+
+}

--- a/1_concepts/src/parallel_list.rs
+++ b/1_concepts/src/parallel_list.rs
@@ -45,10 +45,10 @@ where T: Copy
         list.get(index)
     }
 
-    fn remove(&mut self, index: usize) -> Option<T> {
-        let mut list = self.list.lock().unwrap();
-        list.remove(index)
-    }
+    // fn remove(&mut self, index: usize) -> Option<T> {
+    //     let mut list = self.list.lock().unwrap();
+    //     list.remove(index)
+    // }
 
     fn update(&mut self, index: usize, value: T) -> Option<T> {
         let mut list = self.list.lock().unwrap();

--- a/1_concepts/src/parallel_node.rs
+++ b/1_concepts/src/parallel_node.rs
@@ -3,16 +3,16 @@ use std::sync::{Arc, Mutex};
 
 pub struct ParallelNode<T> {
     pub value: T,
-    pub next: Arc<Mutex<Option<ParallelNode<T>>>>,
-    pub prev: Weak<Mutex<Option<ParallelNode<T>>>>
+    pub next: Option<Arc<Mutex<ParallelNode<T>>>>,
+    pub prev: Option<Weak<Mutex<ParallelNode<T>>>>
 }
 
 impl<T> ParallelNode<T> {
     pub fn new(value: T) -> Self {
         ParallelNode {
             value,
-            next: Arc::new(Mutex::new(None)),
-            prev: Arc::downgrade(&Arc::new(Mutex::new(None))),
+            next: None,
+            prev: None,
         }
     }
 }
@@ -25,7 +25,7 @@ mod tests {
     fn test_parallel_node() {
         let node = ParallelNode::new(1);
         assert_eq!(node.value, 1);
-        assert!(node.next.lock().unwrap().is_none());
-        assert!(node.prev.upgrade().is_none());
+        assert!(node.next.is_none());
+        assert!(node.prev.is_none());
     }
 }

--- a/1_concepts/src/parallel_node.rs
+++ b/1_concepts/src/parallel_node.rs
@@ -1,0 +1,31 @@
+use std::sync::Weak;
+use std::sync::{Arc, Mutex};
+
+pub struct ParallelNode<T> {
+    pub value: T,
+    pub next: Arc<Mutex<Option<ParallelNode<T>>>>,
+    pub prev: Weak<Mutex<Option<ParallelNode<T>>>>
+}
+
+impl<T> ParallelNode<T> {
+    pub fn new(value: T) -> Self {
+        ParallelNode {
+            value,
+            next: Arc::new(Mutex::new(None)),
+            prev: Arc::downgrade(&Arc::new(Mutex::new(None))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parallel_node() {
+        let node = ParallelNode::new(1);
+        assert_eq!(node.value, 1);
+        assert!(node.next.lock().unwrap().is_none());
+        assert!(node.prev.upgrade().is_none());
+    }
+}

--- a/1_concepts/src/real_parallel_list.rs
+++ b/1_concepts/src/real_parallel_list.rs
@@ -1,0 +1,281 @@
+use std::sync::{Arc, Mutex};
+use crate::list::List;
+use crate::parallel_node::ParallelNode;
+
+type Node<T> = Arc<Mutex<ParallelNode<T>>>;
+
+fn new_node<T>(value: T) -> Option<Node<T>> {
+    Some(Arc::new(Mutex::new(ParallelNode::new(value))))
+}
+
+
+pub struct ParallelDoublyLinkedList<T> {
+    head: Arc<Mutex<Option<Node<T>>>>,
+    tail: Arc<Mutex<Option<Node<T>>>>,
+    length: Arc<Mutex<usize>>
+}
+
+impl<T> ParallelDoublyLinkedList<T> {
+    pub fn new() -> Self {
+        ParallelDoublyLinkedList {
+            head: Arc::new(Mutex::new(None)),
+            tail: Arc::new(Mutex::new(None)),
+            length: Arc::new(Mutex::new(0)),
+        }
+    }
+
+    fn new_head(&mut self, value: T) {
+        let node = new_node(value);
+
+        let mut length = self.length.lock().unwrap();
+        let mut head = self.head.lock().unwrap();
+        let mut tail = self.tail.lock().unwrap();
+
+        *head = node.clone();
+        *tail = node;
+
+        *length = 1;
+    }
+
+    /// Function that appends node_right to node_left
+    fn append_to_node_right(node_left_link: Node<T>, node_right_link: Node<T>) {
+            let mut node_left = node_left_link.lock().unwrap();
+            let mut node_right = node_right_link.lock().unwrap();
+
+            node_right.next = None;
+            node_right.prev = Some(Arc::downgrade(&node_left_link));
+
+            node_left.next = Some(node_right_link.clone());
+    }
+
+    // only pop from tail, so next to left is tail
+    fn pop_right(node_left_link: Node<T>) {
+        let mut node_left = node_left_link.lock().unwrap();
+        let mut node_right = node_left.next.take().unwrap();
+
+        let mut node_right = node_right.lock().unwrap();
+
+        node_right.prev = None;
+    }
+
+    fn get_node(&self, index: usize) -> Option<Node<T>> {
+        let length = self.length.lock().unwrap();
+        // need to lock tail to items not be removed while we are getting
+        let tail = self.tail.lock().unwrap();
+
+        if index >= *length {
+            return None;
+        }
+
+
+        let head = self.head.clone();
+        // need to lock head to items not be removed while we are getting
+        let head = head.lock().unwrap();
+        let mut node = head.clone().unwrap();
+
+        for _ in 0..index {
+            let next = node.lock().unwrap().next.clone().unwrap();
+            node = next;
+        }
+
+        Some(node)
+    }
+}
+
+impl<T> Clone for ParallelDoublyLinkedList<T> {
+    fn clone(&self) -> Self {
+        ParallelDoublyLinkedList {
+            head: self.head.clone(),
+            tail: self.tail.clone(),
+            length: self.length.clone(),
+        }
+    }
+}
+
+impl<T> List<T> for ParallelDoublyLinkedList<T>
+where T: Copy
+{
+    fn push(&mut self, value: T) -> Option<usize> {
+        return if self.head.lock().unwrap().is_none() {
+            self.new_head(value);
+            Some(0)
+        } else {
+            let new_node = new_node(value).unwrap();
+            let mut length = self.length.lock().unwrap();
+            let mut tail_option = self.tail.lock().unwrap();
+
+            let tail = tail_option.as_ref().unwrap();
+
+
+            let index = *length;
+            ParallelDoublyLinkedList::append_to_node_right(tail.clone(), new_node.clone());
+
+            *tail_option = Some(new_node);
+            *length += 1;
+
+            Some(index)
+        }
+    }
+
+    fn pop(&mut self) -> Option<T> {
+        let mut length = self.length.lock().unwrap();
+        let mut tail_option = self.tail.lock().unwrap();
+
+        return if *length == 0 {
+            None
+        } else if *length == 1 {
+            let tail = tail_option.take().unwrap();
+            let value = tail.lock().unwrap().value;
+
+            self.head.lock().unwrap().take();
+
+            *length = 0;
+
+            Some(value)
+        } else {
+            let tail = tail_option.take().unwrap();
+            let value = tail.lock().unwrap().value;
+            let prev = tail.lock().unwrap().prev.clone().unwrap().upgrade().unwrap();
+
+            ParallelDoublyLinkedList::pop_right(prev.clone());
+
+            *tail_option = Some(prev);
+            *length -= 1;
+
+            Some(value)
+        }
+    }
+
+    fn get(&self, index: usize) -> Option<T> {
+        let node = self.get_node(index);
+        node.map(|n| n.lock().unwrap().value)
+    }
+
+    fn update(&mut self, index: usize, value: T) -> Option<T> {
+        todo!()
+    }
+
+    fn clear(&mut self) {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread::sleep;
+    use crate::list::List;
+    use crate::real_parallel_list::ParallelDoublyLinkedList;
+
+    #[test]
+    fn test_parallel_doubly_linked_list() {
+        let list = ParallelDoublyLinkedList::<u32>::new();
+
+        assert_eq!(list.length.lock().unwrap().clone(), 0);
+        assert!(list.head.lock().unwrap().clone().is_none());
+        assert!(list.tail.lock().unwrap().clone().is_none());
+    }
+
+    #[test]
+    fn test_parallel_doubly_linked_list_push() {
+        let mut list = ParallelDoublyLinkedList::<u32>::new();
+
+        list.push(1);
+        list.push(2);
+        list.push(3);
+
+        assert_eq!(list.length.lock().unwrap().clone(), 3);
+        assert_eq!(list.head.lock().unwrap().clone().unwrap().lock().unwrap().value, 1);
+        assert_eq!(list.tail.lock().unwrap().clone().unwrap().lock().unwrap().value, 3);
+    }
+
+    #[test]
+    fn test_parallel_doubly_linked_list_push_parallel() {
+        let mut list = ParallelDoublyLinkedList::<u32>::new();
+
+        let mut list_clone = list.clone();
+
+        let handle = std::thread::spawn(move || {
+            list_clone.push(1);
+            list_clone.push(2);
+            list_clone.push(3);
+        });
+
+        let pos4= list.push(4);
+        let pos5 = list.push(5);
+        let pos6 = list.push(6);
+
+        handle.join().unwrap();
+
+        assert_eq!(list.length.lock().unwrap().clone(), 6);
+
+        assert!(pos4.is_some());
+        assert!(pos5.is_some());
+        assert!(pos6.is_some());
+
+        assert_eq!(list.get(pos4.unwrap()).unwrap(), 4);
+        assert_eq!(list.get(pos5.unwrap()).unwrap(), 5);
+        assert_eq!(list.get(pos6.unwrap()).unwrap(), 6);
+    }
+
+    #[test]
+    fn test_parallel_doubly_linked_list_pop() {
+        let mut list = ParallelDoublyLinkedList::new();
+
+        list.push(1);
+        list.push(2);
+        list.push(3);
+
+        assert_eq!(list.pop(), Some(3));
+        assert_eq!(list.pop(), Some(2));
+        assert_eq!(list.pop(), Some(1));
+        assert_eq!(list.pop(), None);
+    }
+
+    #[test]
+    fn test_parallel_doubly_linked_list_pop_parallel() {
+        let mut list = ParallelDoublyLinkedList::<u32>::new();
+
+        let mut list_clone = list.clone();
+
+        let handle = std::thread::spawn(move || {
+            list_clone.push(1);
+            list_clone.push(2);
+            list_clone.push(3);
+        });
+
+        handle.join().unwrap();
+
+        assert_eq!(list.pop(), Some(3));
+        assert_eq!(list.pop(), Some(2));
+        assert_eq!(list.pop(), Some(1));
+    }
+
+    #[test]
+    fn test_parallel_doubly_linked_list_many() {
+        let list = ParallelDoublyLinkedList::<u32>::new();
+
+        let mut handles = vec![];
+
+        for i in 0..10 {
+            let mut list_clone = list.clone();
+            let handle = std::thread::spawn(move || {
+                println!("Pushed in thread {} on pos {:?}", i, list_clone.push(i));
+                println!("Pushed in thread {} on pos {:?}", i, list_clone.push(i + 1));
+
+                println!("Popped in thread {} a value {:?}", i, list_clone.pop());
+
+                println!("Pushed in thread {} on pos {:?}", i, list_clone.push(i + 2));
+
+                println!("Popped in thread {} a value {:?}", i, list_clone.pop());
+            });
+            handles.push(handle);
+        }
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        assert_eq!(list.length.lock().unwrap().clone(), 10);
+    }
+}
+

--- a/2_idioms/2_1_type_safety/src/main.rs
+++ b/2_idioms/2_1_type_safety/src/main.rs
@@ -1,3 +1,7 @@
+pub mod post;
+pub mod user;
+pub mod wrapper;
+
 fn main() {
     println!("Implement me!");
 }

--- a/2_idioms/2_1_type_safety/src/post.rs
+++ b/2_idioms/2_1_type_safety/src/post.rs
@@ -1,0 +1,44 @@
+use crate::user;
+use crate::wrapper::New;
+
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Id(u64);
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Title(String);
+impl Title {
+    pub fn new() -> Title {
+        Title(String::new())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Body(String);
+impl Body {
+    pub fn new() -> Body {
+        Body(String::new())
+    }
+}
+
+
+#[derive(Clone)]
+pub struct Post<Status> {
+    id: Id,
+    user_id: user::Id,
+    title: Title,
+    body: Body,
+    status: Status
+}
+
+impl Post<New> {
+    pub fn new(id: Id, user_id: user::Id) -> Post<New> {
+        Post {
+            id,
+            user_id,
+            title: Title::new(),
+            body: Body::new(),
+            status: New(),
+        }
+    }
+}

--- a/2_idioms/2_1_type_safety/src/post.rs
+++ b/2_idioms/2_1_type_safety/src/post.rs
@@ -1,25 +1,15 @@
 use crate::user;
-use crate::wrapper::New;
+use crate::wrapper::{Deleted, New, Published, Unmoderated};
 
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Id(u64);
+pub struct Id(pub u64);
 
-#[derive(Clone, Debug, PartialEq)]
-pub struct Title(String);
-impl Title {
-    pub fn new() -> Title {
-        Title(String::new())
-    }
-}
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct Title(pub String);
 
-#[derive(Clone, Debug, PartialEq)]
-pub struct Body(String);
-impl Body {
-    pub fn new() -> Body {
-        Body(String::new())
-    }
-}
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct Body(pub String);
 
 
 #[derive(Clone)]
@@ -36,9 +26,128 @@ impl Post<New> {
         Post {
             id,
             user_id,
-            title: Title::new(),
-            body: Body::new(),
+            title: Title::default(),
+            body: Body::default(),
             status: New(),
         }
+    }
+
+    pub fn publish(self) -> Post<Unmoderated> {
+        self.into()
+    }
+}
+
+impl Post<New> {
+    pub fn set_title(&mut self, title: Title) {
+        self.title = title;
+    }
+
+    pub fn set_body(&mut self, body: Body) {
+        self.body = body;
+    }
+}
+
+impl Post<Unmoderated> {
+    pub fn deny(self) -> Post<Deleted> {
+        self.into()
+    }
+
+    pub fn allow(self) -> Post<Published> {
+        self.into()
+    }
+}
+
+impl Post<Published> {
+    fn delete(self) -> Post<Deleted> {
+        self.into()
+    }
+}
+
+impl From<Post<New>> for Post<Unmoderated> {
+    fn from(post: Post<New>) -> Post<Unmoderated> {
+        Post {
+            id: post.id,
+            user_id: post.user_id,
+            title: post.title,
+            body: post.body,
+            status: Unmoderated(),
+        }
+    }
+}
+
+impl From<Post<Unmoderated>> for Post<Deleted> {
+    fn from(post: Post<Unmoderated>) -> Post<Deleted> {
+        Post {
+            id: post.id,
+            user_id: post.user_id,
+            title: post.title,
+            body: post.body,
+            status: Deleted(),
+        }
+    }
+}
+
+impl From<Post<Unmoderated>> for Post<Published> {
+    fn from(post: Post<Unmoderated>) -> Post<Published> {
+        Post {
+            id: post.id,
+            user_id: post.user_id,
+            title: post.title,
+            body: post.body,
+            status: Published(),
+        }
+    }
+}
+
+impl From<Post<Published>> for Post<Deleted> {
+    fn from(post: Post<Published>) -> Post<Deleted> {
+        Post {
+            id: post.id,
+            user_id: post.user_id,
+            title: post.title,
+            body: post.body,
+            status: Deleted(),
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use crate::post::{Id, Post};
+    use crate::user;
+    use crate::wrapper::{Deleted, New, Published, Unmoderated};
+
+    #[test]
+    fn test_post_actions_deny() {
+        let id = Id(1);
+        let user_id = user::Id(1);
+
+        let post = Post::new(id, user_id);
+        assert_eq!(post.status, New());
+
+        let published_post = post.publish();
+        assert_eq!(published_post.status, Unmoderated());
+
+        let denied_post = published_post.deny();
+        assert_eq!(denied_post.status, Deleted());
+    }
+
+    #[test]
+    fn test_post_actions_allow() {
+        let id = Id(1);
+        let user_id = user::Id(1);
+
+        let post = Post::new(id, user_id);
+        assert_eq!(post.status, New());
+
+        let published_post = post.publish();
+        assert_eq!(published_post.status, Unmoderated());
+
+        let allowed_post = published_post.allow();
+        assert_eq!(allowed_post.status, Published());
+
+        let deleted_post = allowed_post.delete();
+        assert_eq!(deleted_post.status, Deleted());
     }
 }

--- a/2_idioms/2_1_type_safety/src/user.rs
+++ b/2_idioms/2_1_type_safety/src/user.rs
@@ -1,3 +1,3 @@
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Id(u64);
+pub struct Id(pub u64);

--- a/2_idioms/2_1_type_safety/src/user.rs
+++ b/2_idioms/2_1_type_safety/src/user.rs
@@ -1,0 +1,3 @@
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Id(u64);

--- a/2_idioms/2_1_type_safety/src/wrapper.rs
+++ b/2_idioms/2_1_type_safety/src/wrapper.rs
@@ -1,0 +1,24 @@
+use crate::post::Post;
+
+pub struct New();
+pub struct Unmoderated();
+pub struct Published();
+pub struct Deleted();
+
+pub enum PostWrapper {
+    New(Post<New>),
+    Unmoderated(Post<Unmoderated>),
+    Published(Post<Published>),
+    Deleted(Post<Deleted>),
+}
+
+pub struct PostFactory {
+    post: PostWrapper
+}
+
+impl PostFactory {
+    pub fn new() -> Post<New> {
+
+    }
+
+}

--- a/2_idioms/2_1_type_safety/src/wrapper.rs
+++ b/2_idioms/2_1_type_safety/src/wrapper.rs
@@ -1,24 +1,9 @@
-use crate::post::Post;
 
+#[derive(Debug, PartialEq)]
 pub struct New();
+#[derive(Debug, PartialEq)]
 pub struct Unmoderated();
+#[derive(Debug, PartialEq)]
 pub struct Published();
+#[derive(Debug, PartialEq)]
 pub struct Deleted();
-
-pub enum PostWrapper {
-    New(Post<New>),
-    Unmoderated(Post<Unmoderated>),
-    Published(Post<Published>),
-    Deleted(Post<Deleted>),
-}
-
-pub struct PostFactory {
-    post: PostWrapper
-}
-
-impl PostFactory {
-    pub fn new() -> Post<New> {
-
-    }
-
-}

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Do not hesitate to ask your mentor/lead with questions, however you won't receiv
     - [ ] [1.8. Thread safety][Step 1.8] (1 day)
     - [ ] [1.9. Phantom types][Step 1.9] (1 day)
 - [ ] [2. Idioms][Step 2] (2 days, after all sub-steps)
-    - [ ] [2.1. Rich types ensure correctness][Step 2.1] (1 day)
+    - [x] [2.1. Rich types ensure correctness][Step 2.1] (1 day)
     - [ ] [2.2. Swapping values with `mem::replace`][Step 2.2] (1 day)
     - [ ] [2.3. Bound behavior, not data][Step 2.3] (1 day)
     - [ ] [2.4. Abstract type in, concrete type out][Step 2.4] (1 day)


### PR DESCRIPTION
Resolves [Step 2.1](https://github.com/Handy-caT/rust-sandbox/blob/2_1_type_safety/2_idioms/2_1_type_safety/README.md)




## Task

For the `Post` type described above, assume the following behavior in our application:
```
+-----+              +-------------+            +-----------+
| New |--publish()-->| Unmoderated |--allow()-->| Published |
+-----+              +-------------+            +-----------+
                           |                          |
                         deny()                    delete()
                           |       +---------+        |
                           +------>| Deleted |<-------+
                                   +---------+
```

Implement this behavior using [typestates idiom][3], so that calling `delete()` on `New` post (or calling `deny()` on `Deleted` post) will be a compile-time error.

[3]: https://yoric.github.io/post/rust-typestate

## Solution

- Provided `Post` type with New, Unmoderated, Published and Deleted states. All states changes are done with `From` trait and methods implemented only for types which can have this method.
