### PR TITLE
Step 2.4: Abstract type in, concrete type out

### DIFF
--- a/2_idioms/2_4_generic_in_type_out/src/main.rs
+++ b/2_idioms/2_4_generic_in_type_out/src/main.rs
@@ -1,34 +1,35 @@
+use std::borrow::Cow;
 use std::net::{IpAddr, SocketAddr};
 
 fn main() {
     println!("Refactor me!");
 
-    let mut err = Error::new("NO_USER".to_string());
-    err.status(404).message("User not found".to_string());
+    let mut err = Error::new("NO_USER");
+    err.status(404).message("User not found");
 }
 
 #[derive(Debug)]
-pub struct Error {
-    code: String,
+pub struct Error<'a> {
+    code: Cow<'a, str>,
     status: u16,
-    message: String,
+    message: Cow<'a, str>,
 }
 
-impl Default for Error {
+impl<'a> Default for Error<'a> {
     #[inline]
     fn default() -> Self {
         Self {
-            code: "UNKNOWN".to_string(),
+            code: Cow::Borrowed("UNKNOWN"),
             status: 500,
-            message: "Unknown error has happened.".to_string(),
+            message: Cow::Borrowed("Unknown error has happened."),
         }
     }
 }
 
-impl Error {
-    pub fn new(code: String) -> Self {
+impl<'a> Error<'a> {
+    pub fn new<S: Into<Cow<'a, str>>>(code: S) -> Self {
         let mut err = Self::default();
-        err.code = code;
+        err.code = code.into();
         err
     }
 
@@ -37,8 +38,8 @@ impl Error {
         self
     }
 
-    pub fn message(&mut self, m: String) -> &mut Self {
-        self.message = m;
+    pub fn message<S: Into<Cow<'a, str>>>(&mut self, m: S) -> &mut Self {
+        self.message = m.into();
         self
     }
 }
@@ -70,6 +71,13 @@ mod server_spec {
 
             server.bind("::1".parse().unwrap(), 9911);
             assert_eq!(format!("{}", server.0.unwrap()), "[::1]:9911");
+        }
+
+        #[test]
+        fn test_error() {
+            let mut err = Error::new("NO_USER");
+            err.status(404).message("User not found");
+            println!("{:?}", err);
         }
     }
 }


### PR DESCRIPTION

Resolves [Step 2.4](https://github.com/Handy-caT/rust-sandbox/tree/2_4_generic_in_type_out/2_idioms/2_4_generic_in_type_out)




## Task

Refactor the code contained in [this step's crate](https://github.com/Handy-caT/rust-sandbox/tree/2_4_generic_in_type_out/2_idioms/2_4_generic_in_type_out/src/main.rs) to make it more efficient, idiomatic, simple and pleasant to use.



## Solution

- `Error` underlying `String` types were changed to `Cow`'s, function input types were changed to generics with `Into<Cow<>>` trait bounds. So now don't need to use "".to_string() or other things
